### PR TITLE
build by cursor: replace local Makepad path deps with pinned git workspace deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # User config (contains API keys)
 # ~/.config/makepad-voice-input/config.json
+
+.env*
+!.env.example

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "aho-corasick"
@@ -14,17 +15,6 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr 2.8.0",
 ]
-
-[[package]]
-name = "approx"
-version = "0.5.1"
-dependencies = [
- "num-traits 0.2.20",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
 
 [[package]]
 name = "arrayvec"
@@ -65,6 +55,7 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 [[package]]
 name = "bitflags"
 version = "2.10.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "bitflags"
@@ -75,10 +66,12 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "byteorder"
 version = "1.5.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "cfg-if"
@@ -188,29 +181,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "downcast-rs"
-version = "2.0.2"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-
-[[package]]
-name = "ena"
-version = "0.14.4"
-dependencies = [
- "makepad-error-log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
 
 [[package]]
 name = "foldhash"
@@ -248,26 +222,9 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 [[package]]
 name = "fxhash"
 version = "0.2.1"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "glam"
-version = "0.30.10"
-dependencies = [
- "approx",
- "libm 0.2.16",
-]
-
-[[package]]
-name = "glamx"
-version = "0.1.3"
-dependencies = [
- "approx",
- "glam",
- "num-traits 0.2.20",
- "simba",
 ]
 
 [[package]]
@@ -278,15 +235,8 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "num-traits 0.2.19",
+ "num-traits",
  "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-dependencies = [
- "foldhash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -295,7 +245,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foldhash",
 ]
 
 [[package]]
@@ -313,19 +263,11 @@ checksum = "96b1d492766a538e49020f97af3e91e0acb718b3b008ed4ab6d39374f42b3e83"
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-dependencies = [
- "equivalent",
- "hashbrown 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown",
 ]
 
 [[package]]
@@ -349,10 +291,6 @@ dependencies = [
  "cfg-if",
  "windows-link 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
 
 [[package]]
 name = "libm"
@@ -390,6 +328,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -397,10 +336,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -408,6 +349,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -416,6 +358,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -436,6 +379,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -443,18 +387,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-live-id",
 ]
@@ -468,6 +416,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "ttf-parser",
 ]
@@ -475,6 +424,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -482,6 +432,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -489,6 +440,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -496,6 +448,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -503,10 +456,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -515,6 +470,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -522,8 +478,10 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-apple-sys",
+ "makepad-error-log",
  "makepad-futures-legacy",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -534,10 +492,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "ash",
  "bitflags 2.10.0",
@@ -553,16 +513,15 @@ dependencies = [
  "makepad-script",
  "makepad-script-std",
  "makepad-shared-bytes",
- "makepad-sparse-voxels",
  "makepad-studio-protocol",
+ "makepad-tsdf",
  "makepad-wasm-bridge",
  "makepad-zune-png",
  "naga",
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "parry3d",
- "smallvec 1.15.1",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -574,10 +533,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -585,12 +546,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -598,6 +560,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -606,19 +569,12 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-
-[[package]]
-name = "makepad-sparse-voxels"
-version = "0.1.0"
-dependencies = [
- "foldhash 0.2.0",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
-]
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "bitflags 2.10.0",
  "makepad-error-log",
@@ -630,14 +586,25 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
 ]
 
 [[package]]
+name = "makepad-tsdf"
+version = "0.1.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
+dependencies = [
+ "makepad-math",
+ "makepad-micro-serde",
+]
+
+[[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -646,6 +613,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -653,6 +621,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -666,10 +635,12 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "simd-adler32",
 ]
@@ -677,6 +648,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.12"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -684,6 +656,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.1"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -692,6 +665,7 @@ dependencies = [
 [[package]]
 name = "memchr"
 version = "2.7.6"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "memchr"
@@ -705,19 +679,19 @@ version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
- "arrayvec 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec",
  "bit-set",
  "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown",
  "hexf-parse",
- "indexmap 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libm 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap",
+ "libm",
  "log",
- "num-traits 0.2.19",
+ "num-traits",
  "once_cell",
  "rustc-hash",
  "spirv",
@@ -775,27 +749,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-dependencies = [
- "num-traits 0.2.20",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.20"
-dependencies = [
- "libm 0.2.16",
+ "libm",
 ]
 
 [[package]]
@@ -809,26 +769,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "parry3d"
-version = "0.26.0"
-dependencies = [
- "approx",
- "arrayvec 0.7.6",
- "bitflags 2.10.0",
- "downcast-rs 2.0.2",
- "either",
- "ena",
- "glamx",
- "indexmap 2.13.0",
- "makepad-error-log",
- "makepad-sparse-voxels",
- "num-traits 0.2.20",
- "simba",
- "smallvec 1.15.1",
- "static_assertions",
-]
 
 [[package]]
 name = "pkg-config"
@@ -848,6 +788,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "bitflags 2.10.0",
  "memchr 2.7.6",
@@ -901,11 +842,12 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -922,6 +864,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "serde"
@@ -967,28 +910,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "simba"
-version = "0.9.1"
-dependencies = [
- "approx",
- "libm 0.2.16",
- "num-complex",
- "num-traits 0.2.20",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.8"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "spirv"
@@ -998,10 +933,6 @@ checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
  "bitflags 2.11.0",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
 
 [[package]]
 name = "syn"
@@ -1037,22 +968,27 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "unicase"
 version = "2.9.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "unicode-ident"
@@ -1063,18 +999,22 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1102,8 +1042,9 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
- "downcast-rs 1.2.1",
+ "downcast-rs",
  "libc",
  "scoped-tls",
  "smallvec 1.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1113,6 +1054,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -1122,6 +1064,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -1130,6 +1073,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -1139,6 +1083,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "log",
  "pkg-config",
@@ -1147,6 +1092,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "windows-collections",
  "windows-core",
@@ -1156,6 +1102,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "windows-core",
 ]
@@ -1163,8 +1110,9 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link 0.2.1 (git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090)",
  "windows-result",
  "windows-strings",
 ]
@@ -1172,13 +1120,10 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
  "windows-core",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
 
 [[package]]
 name = "windows-link"
@@ -1187,17 +1132,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link 0.2.1 (git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090)",
 ]
 
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
+source = "git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090#ce7da33f1d387b786abeb03b0bed73c79b7ca090"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link 0.2.1 (git+https://github.com/makepad/makepad.git?rev=ce7da33f1d387b786abeb03b0bed73c79b7ca090)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 resolver = "2"
 members = ["macos-sys", "app"]
+
+# Pinned to one Makepad commit so clones build without a local makepad checkout.
+# (Some registry mirrors lag behind crates.io for makepad 2.x; git uses GitHub directly.)
+[workspace.dependencies]
+makepad-widgets = { git = "https://github.com/makepad/makepad.git", rev = "ce7da33f1d387b786abeb03b0bed73c79b7ca090" }
+makepad-objc-sys = { git = "https://github.com/makepad/makepad.git", rev = "ce7da33f1d387b786abeb03b0bed73c79b7ca090" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-makepad-widgets = { path = "/Users/zhangalex/Work/Projects/FW/robius/makepad/widgets" }
+makepad-widgets.workspace = true
 macos-sys = { path = "../macos-sys" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/app/src/audio.rs
+++ b/app/src/audio.rs
@@ -198,3 +198,15 @@ pub fn encode_wav(samples: &[f32], sample_rate: u32) -> Vec<u8> {
 
     buf
 }
+
+/// Raw mono float32 little-endian PCM at 16 kHz (no header).
+/// Qwen3-ASR / vLLM streaming servers decode `application/octet-stream` chunks as `float32`
+/// (see multimodal pipeline); **s16le is misinterpreted** and often becomes all-zero `float32`.
+pub fn pcm_f32_le_from_f32(samples: &[f32]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(samples.len() * 4);
+    for &sample in samples {
+        let clamped = sample.clamp(-1.0, 1.0);
+        buf.extend_from_slice(&clamped.to_le_bytes());
+    }
+    buf
+}

--- a/app/src/config.rs
+++ b/app/src/config.rs
@@ -24,12 +24,25 @@ pub struct HotkeyConfig {
     pub trigger: String,
 }
 
+/// How the app talks to the speech recognition HTTP service.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AsrBackend {
+    /// OminiX-style `POST /v1/audio/transcriptions` with JSON + base64 WAV.
+    #[default]
+    OminixJson,
+    /// vLLM / Qwen streaming ASR: `POST /api/start` → `/api/chunk` → `/api/finish` (octet-stream float32le PCM @ 16 kHz).
+    QwenStreaming,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OminixApiConfig {
     #[serde(default = "default_api_url")]
     pub base_url: String,
     #[serde(default = "default_asr_model")]
     pub asr_model: String,
+    #[serde(default)]
+    pub asr_backend: AsrBackend,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -122,6 +135,7 @@ impl Default for OminixApiConfig {
         Self {
             base_url: default_api_url(),
             asr_model: default_asr_model(),
+            asr_backend: AsrBackend::default(),
         }
     }
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -30,6 +30,26 @@ const STATE_RECORDING: u8 = 1;
 const STATE_TRANSCRIBING: u8 = 2;
 const STATE_REFINING: u8 = 3;
 
+/// Qwen/vLLM streaming ASR in-flight step (after `POST /api/start`).
+#[allow(clippy::enum_variant_names)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AsrStreamPhase {
+    WaitStart,
+    WaitChunk,
+    WaitFinish,
+}
+
+/// Settings test for streaming ASR: start → chunk → finish.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+#[repr(u8)]
+enum TestAsrStreamPhase {
+    #[default]
+    Idle,
+    WaitStart,
+    WaitChunk,
+    WaitFinish,
+}
+
 script_mod! {
     use mod.prelude.widgets.*
 
@@ -115,7 +135,7 @@ script_mod! {
 
             settings_window := Window{
                 window.title: "Voice Input Settings"
-                window.inner_size: vec2(480, 560)
+                window.inner_size: vec2(480, 620)
                 window.position: vec2(500, 200)
                 body +: {
                     ScrollYView{
@@ -123,7 +143,11 @@ script_mod! {
                         flow: Down spacing: 12 padding: 24
                         new_batch: true
 
-                        Label{ text: "ominix-api" draw_text.color: #xffffff draw_text.text_style.font_size: 16 }
+                        Label{ text: "Speech / ASR API" draw_text.color: #xffffff draw_text.text_style.font_size: 16 }
+                        Label{ text: "Backend" draw_text.color: #xaaaaaa draw_text.text_style.font_size: 11 }
+                        asr_backend_dropdown := DropDown{
+                            labels: ["OminiX (JSON + base64)", "Qwen streaming (vLLM)"]
+                        }
                         Label{ text: "Base URL" draw_text.color: #xaaaaaa draw_text.text_style.font_size: 11 }
                         api_url_input := TextInput{ width: Fill height: 36 empty_text: "http://localhost:8080" }
 
@@ -192,6 +216,12 @@ struct Inner {
     last_wav: Vec<u8>,
     last_transcription: String,
     inject_state: text_inject::InjectState,
+    /// s16le PCM for `POST /api/chunk` (Qwen streaming); filled before start request.
+    asr_stream_pcm: Vec<u8>,
+    asr_stream_session_id: String,
+    asr_stream_phase: Option<AsrStreamPhase>,
+    test_asr_stream_phase: TestAsrStreamPhase,
+    test_asr_stream_session_id: String,
 }
 
 #[derive(Script, ScriptHook)]
@@ -311,6 +341,12 @@ impl App {
         let cfg = &self.inner.config;
         self.ui.text_input(cx, ids!(api_url_input))
             .set_text(cx, &cfg.ominix_api.base_url);
+        let asr_backend_idx = match cfg.ominix_api.asr_backend {
+            config::AsrBackend::OminixJson => 0,
+            config::AsrBackend::QwenStreaming => 1,
+        };
+        self.ui.drop_down(cx, ids!(asr_backend_dropdown))
+            .set_selected_item(cx, asr_backend_idx);
         self.ui.text_input(cx, ids!(llm_url_input))
             .set_text(cx, &cfg.llm_refine.api_base_url);
         self.ui.text_input(cx, ids!(llm_key_input))
@@ -333,8 +369,13 @@ impl App {
         let llm_key = self.ui.text_input(cx, ids!(llm_key_input)).text();
         let llm_model = self.ui.text_input(cx, ids!(llm_model_input)).text();
         let lang_idx = self.ui.drop_down(cx, ids!(language_dropdown)).selected_item();
+        let asr_backend_idx = self.ui.drop_down(cx, ids!(asr_backend_dropdown)).selected_item();
 
         self.inner.config.ominix_api.base_url = api_url;
+        self.inner.config.ominix_api.asr_backend = match asr_backend_idx {
+            1 => config::AsrBackend::QwenStreaming,
+            _ => config::AsrBackend::OminixJson,
+        };
         self.inner.config.llm_refine.api_base_url = llm_url;
         self.inner.config.llm_refine.api_key = llm_key;
         self.inner.config.llm_refine.model = llm_model;
@@ -355,12 +396,35 @@ impl App {
     }
 
     fn test_connection(&mut self, cx: &mut Cx) {
-        let url = format!(
-            "{}/v1/models",
-            self.ui.text_input(cx, ids!(api_url_input)).text().trim_end_matches('/')
-        );
-        let req = HttpRequest::new(url, HttpMethod::GET);
-        cx.http_request(live_id!(test_connection), req);
+        let base = self.ui.text_input(cx, ids!(api_url_input)).text();
+        let base = base.trim_end_matches('/');
+        let asr_backend_idx = self.ui.drop_down(cx, ids!(asr_backend_dropdown)).selected_item();
+
+        self.inner.test_asr_stream_phase = TestAsrStreamPhase::Idle;
+        self.inner.test_asr_stream_session_id.clear();
+
+        if asr_backend_idx == 1 {
+            self.inner.test_asr_stream_phase = TestAsrStreamPhase::WaitStart;
+            let app_lang = match self.ui.drop_down(cx, ids!(language_dropdown)).selected_item() {
+                0 => "zh",
+                1 => "en",
+                2 => "zh-TW",
+                3 => "ja",
+                4 => "ko",
+                5 => "wen",
+                _ => "zh",
+            };
+            transcribe::send_streaming_start(
+                cx,
+                transcribe::TEST_ASR_STREAM_START_ID,
+                base,
+                app_lang,
+            );
+        } else {
+            let url = format!("{base}/v1/models");
+            let req = HttpRequest::new(url, HttpMethod::GET);
+            cx.http_request(live_id!(test_connection), req);
+        }
         self.ui.label(cx, ids!(settings_status)).set_text(cx, "Testing...");
     }
 
@@ -387,7 +451,7 @@ impl App {
         // configure_window triggers makeKeyAndOrderFront on macOS
         settings.configure_window(
             cx,
-            dvec2(480.0, 560.0),
+            dvec2(480.0, 620.0),
             dvec2(500.0, 200.0),
             false,
             "Voice Input Settings".to_string(),
@@ -436,12 +500,39 @@ impl App {
         }
         self.inner.last_wav = audio::encode_wav(&samples, 16_000);
         self.ui.label(cx, ids!(transcript_label)).set_text(cx, "🔍 Transcribing...");
-        transcribe::send_transcribe_request(
-            cx,
-            &self.inner.config.ominix_api.base_url,
-            &self.inner.last_wav,
-            &self.inner.config.language,
-        );
+        let base = self.inner.config.ominix_api.base_url.trim_end_matches('/');
+        match self.inner.config.ominix_api.asr_backend {
+            config::AsrBackend::OminixJson => {
+                transcribe::send_transcribe_request(
+                    cx,
+                    base,
+                    &self.inner.last_wav,
+                    &self.inner.config.language,
+                    &self.inner.config.ominix_api.asr_model,
+                );
+            }
+            config::AsrBackend::QwenStreaming => {
+                self.inner.asr_stream_pcm = audio::pcm_f32_le_from_f32(&samples);
+                self.inner.asr_stream_phase = Some(AsrStreamPhase::WaitStart);
+                transcribe::send_streaming_start(
+                    cx,
+                    transcribe::ASR_STREAM_START_ID,
+                    base,
+                    &self.inner.config.language,
+                );
+            }
+        }
+    }
+
+    fn clear_asr_stream_state(&mut self) {
+        self.inner.asr_stream_pcm.clear();
+        self.inner.asr_stream_session_id.clear();
+        self.inner.asr_stream_phase = None;
+    }
+
+    fn fail_streaming_asr(&mut self, cx: &mut Cx, msg: &str) {
+        self.clear_asr_stream_state();
+        self.handle_error(cx, msg);
     }
 
     fn handle_transcribe_result(&mut self, cx: &mut Cx, text: &str) {
@@ -593,6 +684,98 @@ impl MatchEvent for App {
                 Ok(text) => self.handle_transcribe_result(cx, &text),
                 Err(e) => self.handle_error(cx, &format!("Transcription failed: {e}")),
             }
+        } else if request_id == transcribe::ASR_STREAM_START_ID {
+            match transcribe::parse_stream_start_response(response) {
+                Ok(sid) => {
+                    self.inner.asr_stream_session_id = sid.clone();
+                    self.inner.asr_stream_phase = Some(AsrStreamPhase::WaitChunk);
+                    let pcm = std::mem::take(&mut self.inner.asr_stream_pcm);
+                    let base = self.inner.config.ominix_api.base_url.trim_end_matches('/');
+                    transcribe::send_streaming_chunk(
+                        cx,
+                        transcribe::ASR_STREAM_CHUNK_ID,
+                        base,
+                        &sid,
+                        &pcm,
+                    );
+                }
+                Err(e) => self.fail_streaming_asr(cx, &format!("ASR start failed: {e}")),
+            }
+        } else if request_id == transcribe::ASR_STREAM_CHUNK_ID {
+            if response.status_code != 200 {
+                self.fail_streaming_asr(cx, &format!("ASR chunk failed: HTTP {}", response.status_code));
+                return;
+            }
+            let _ = transcribe::parse_streaming_asr_text(response);
+            self.inner.asr_stream_phase = Some(AsrStreamPhase::WaitFinish);
+            let base = self.inner.config.ominix_api.base_url.trim_end_matches('/');
+            let sid = self.inner.asr_stream_session_id.clone();
+            transcribe::send_streaming_finish(cx, transcribe::ASR_STREAM_FINISH_ID, base, &sid);
+        } else if request_id == transcribe::ASR_STREAM_FINISH_ID {
+            match transcribe::parse_streaming_asr_text(response) {
+                Ok(text) => {
+                    self.clear_asr_stream_state();
+                    self.handle_transcribe_result(cx, &text);
+                }
+                Err(e) => self.fail_streaming_asr(cx, &format!("ASR finish failed: {e}")),
+            }
+        } else if request_id == transcribe::TEST_ASR_STREAM_START_ID {
+            if self.inner.test_asr_stream_phase != TestAsrStreamPhase::WaitStart {
+                return;
+            }
+            match transcribe::parse_stream_start_response(response) {
+                Ok(sid) => {
+                    self.inner.test_asr_stream_session_id = sid.clone();
+                    self.inner.test_asr_stream_phase = TestAsrStreamPhase::WaitChunk;
+                    let base = self
+                        .ui
+                        .text_input(cx, ids!(api_url_input))
+                        .text()
+                        .trim_end_matches('/')
+                        .to_string();
+                    transcribe::send_streaming_chunk(
+                        cx,
+                        transcribe::TEST_ASR_STREAM_CHUNK_ID,
+                        &base,
+                        &sid,
+                        transcribe::test_stream_silence_pcm(),
+                    );
+                }
+                Err(e) => {
+                    self.inner.test_asr_stream_phase = TestAsrStreamPhase::Idle;
+                    self.ui
+                        .label(cx, ids!(settings_status))
+                        .set_text(cx, &format!("Error: {e}"));
+                }
+            }
+        } else if request_id == transcribe::TEST_ASR_STREAM_CHUNK_ID {
+            if self.inner.test_asr_stream_phase != TestAsrStreamPhase::WaitChunk {
+                return;
+            }
+            if response.status_code != 200 {
+                self.inner.test_asr_stream_phase = TestAsrStreamPhase::Idle;
+                self.ui
+                    .label(cx, ids!(settings_status))
+                    .set_text(cx, &format!("Error: HTTP {}", response.status_code));
+                return;
+            }
+            self.inner.test_asr_stream_phase = TestAsrStreamPhase::WaitFinish;
+            let base_owned = self.ui.text_input(cx, ids!(api_url_input)).text();
+            let base = base_owned.trim_end_matches('/');
+            let sid = self.inner.test_asr_stream_session_id.clone();
+            transcribe::send_streaming_finish(cx, transcribe::TEST_ASR_STREAM_FINISH_ID, base, &sid);
+        } else if request_id == transcribe::TEST_ASR_STREAM_FINISH_ID {
+            self.inner.test_asr_stream_phase = TestAsrStreamPhase::Idle;
+            self.inner.test_asr_stream_session_id.clear();
+            if response.status_code == 200 {
+                self.ui
+                    .label(cx, ids!(settings_status))
+                    .set_text(cx, "Connected (streaming)");
+            } else {
+                self.ui
+                    .label(cx, ids!(settings_status))
+                    .set_text(cx, &format!("Error: HTTP {}", response.status_code));
+            }
         } else if request_id == llm_refine::LLM_REFINE_REQUEST_ID {
             match llm_refine::parse_refine_response(response) {
                 Ok(text) => self.handle_refine_result(cx, &text),
@@ -616,6 +799,20 @@ impl MatchEvent for App {
     fn handle_http_request_error(&mut self, cx: &mut Cx, request_id: LiveId, _err: &HttpError) {
         if request_id == transcribe::TRANSCRIBE_REQUEST_ID {
             self.handle_error(cx, "Service unavailable");
+        } else if request_id == transcribe::ASR_STREAM_START_ID
+            || request_id == transcribe::ASR_STREAM_CHUNK_ID
+            || request_id == transcribe::ASR_STREAM_FINISH_ID
+        {
+            self.fail_streaming_asr(cx, "ASR service unavailable");
+        } else if request_id == transcribe::TEST_ASR_STREAM_START_ID
+            || request_id == transcribe::TEST_ASR_STREAM_CHUNK_ID
+            || request_id == transcribe::TEST_ASR_STREAM_FINISH_ID
+        {
+            self.inner.test_asr_stream_phase = TestAsrStreamPhase::Idle;
+            self.inner.test_asr_stream_session_id.clear();
+            self.ui
+                .label(cx, ids!(settings_status))
+                .set_text(cx, "Connection failed");
         } else if request_id == llm_refine::LLM_REFINE_REQUEST_ID {
             let original = self.inner.last_transcription.clone();
             self.inject_text(cx, &original);

--- a/app/src/transcribe.rs
+++ b/app/src/transcribe.rs
@@ -1,13 +1,27 @@
 use makepad_widgets::*;
+use serde_json::Value as JsonValue;
 
-/// Request ID for transcription HTTP calls.
+/// Request ID for OminiX-style single-shot transcription.
 pub const TRANSCRIBE_REQUEST_ID: LiveId = live_id!(transcribe);
 
-/// Send a transcription request to ominix-api.
-///
-/// The API expects JSON with base64-encoded audio:
-/// {"file": "<base64 WAV>", "language": "zh"}
-pub fn send_transcribe_request(cx: &mut Cx, base_url: &str, wav_data: &[u8], language: &str) {
+/// Streaming ASR: matches Python `QwenStreamingASRClient` (start → chunk → finish).
+pub const ASR_STREAM_START_ID: LiveId = live_id!(asr_stream_start);
+pub const ASR_STREAM_CHUNK_ID: LiveId = live_id!(asr_stream_chunk);
+pub const ASR_STREAM_FINISH_ID: LiveId = live_id!(asr_stream_finish);
+
+/// Settings "Test connection" for streaming ASR (start → minimal chunk → finish).
+pub const TEST_ASR_STREAM_START_ID: LiveId = live_id!(test_asr_stream_start);
+pub const TEST_ASR_STREAM_CHUNK_ID: LiveId = live_id!(test_asr_stream_chunk);
+pub const TEST_ASR_STREAM_FINISH_ID: LiveId = live_id!(test_asr_stream_finish);
+
+/// Send a transcription request to ominix-api (JSON + base64 WAV).
+pub fn send_transcribe_request(
+    cx: &mut Cx,
+    base_url: &str,
+    wav_data: &[u8],
+    language: &str,
+    model: &str,
+) {
     let url = format!("{}/v1/audio/transcriptions", base_url.trim_end_matches('/'));
 
     // Qwen3-ASR expects full language names, not ISO codes
@@ -17,16 +31,17 @@ pub fn send_transcribe_request(cx: &mut Cx, base_url: &str, wav_data: &[u8], lan
         "ja" => "Japanese",
         "ko" => "Korean",
         "zh-TW" => "Chinese",
-        "wen" => "Chinese",  // 文言文：用中文 ASR 识别白话，LLM 转文言
+        "wen" => "Chinese", // 文言文：用中文 ASR 识别白话，LLM 转文言
         _ => language,
     };
 
     let b64 = base64_encode(wav_data);
-
-    let body = format!(
-        r#"{{"file":"{}","language":"{}","model":"qwen3-asr"}}"#,
-        b64, asr_language
-    );
+    let body = serde_json::json!({
+        "file": b64,
+        "language": asr_language,
+        "model": model,
+    })
+    .to_string();
 
     let mut req = HttpRequest::new(url, HttpMethod::POST);
     req.set_header("Content-Type".into(), "application/json".into());
@@ -35,8 +50,134 @@ pub fn send_transcribe_request(cx: &mut Cx, base_url: &str, wav_data: &[u8], lan
     cx.http_request(TRANSCRIBE_REQUEST_ID, req);
 }
 
-/// Parse the transcription response.
-/// Expected format: {"text": "transcribed text"}
+/// Map app language to ISO code for `/api/start` (matches typical `ASR_LANGUAGE` env usage).
+pub fn streaming_language_code(language: &str) -> &'static str {
+    match language {
+        "zh" | "wen" => "zh",
+        "en" => "en",
+        "zh-TW" => "zh-TW",
+        "ja" => "ja",
+        "ko" => "ko",
+        _ => "zh",
+    }
+}
+
+/// `POST {base}/api/start` — JSON `sample_rate`, `language`, `task`.
+pub fn send_streaming_start(cx: &mut Cx, request_id: LiveId, base_url: &str, language: &str) {
+    let url = format!("{}/api/start", base_url.trim_end_matches('/'));
+    let lang = streaming_language_code(language);
+    let body = serde_json::json!({
+        "sample_rate": 16000_i32,
+        "language": lang,
+        "task": "transcribe",
+    })
+    .to_string();
+
+    let mut req = HttpRequest::new(url, HttpMethod::POST);
+    req.set_header("Content-Type".into(), "application/json".into());
+    req.set_body(body.into_bytes());
+    cx.http_request(request_id, req);
+}
+
+/// `POST {base}/api/chunk?session_id=...` — raw mono float32 little-endian PCM at 16 kHz.
+pub fn send_streaming_chunk(
+    cx: &mut Cx,
+    request_id: LiveId,
+    base_url: &str,
+    session_id: &str,
+    pcm: &[u8],
+) {
+    let url = format!(
+        "{}/api/chunk?session_id={}",
+        base_url.trim_end_matches('/'),
+        query_escape(session_id)
+    );
+    let mut req = HttpRequest::new(url, HttpMethod::POST);
+    req.set_header("Content-Type".into(), "application/octet-stream".into());
+    req.set_body(pcm.to_vec());
+    cx.http_request(request_id, req);
+}
+
+/// `POST {base}/api/finish?session_id=...`
+pub fn send_streaming_finish(cx: &mut Cx, request_id: LiveId, base_url: &str, session_id: &str) {
+    let url = format!(
+        "{}/api/finish?session_id={}",
+        base_url.trim_end_matches('/'),
+        query_escape(session_id)
+    );
+    let req = HttpRequest::new(url, HttpMethod::POST);
+    cx.http_request(request_id, req);
+}
+
+/// Parse `{"session_id":"..."}` from `/api/start`.
+pub fn parse_stream_start_response(response: &HttpResponse) -> Result<String, String> {
+    if response.status_code != 200 {
+        return Err(format!("HTTP {}", response.status_code));
+    }
+    let body_str = response
+        .body_string()
+        .ok_or_else(|| "Empty response body".to_string())?;
+    let v: JsonValue =
+        serde_json::from_str(&body_str).map_err(|e| format!("Invalid JSON: {e}"))?;
+    v.get("session_id")
+        .and_then(|x| x.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| format!("Missing session_id: {body_str}"))
+}
+
+/// Extract transcript text from streaming chunk/finish payloads (Python `_extract_text`).
+pub fn parse_streaming_asr_text(response: &HttpResponse) -> Result<String, String> {
+    if response.status_code != 200 {
+        return Err(format!("HTTP {}", response.status_code));
+    }
+    let body_str = response
+        .body_string()
+        .ok_or_else(|| "Empty response body".to_string())?;
+    extract_streaming_text(&body_str)
+}
+
+fn extract_streaming_text(body_str: &str) -> Result<String, String> {
+    let v: JsonValue =
+        serde_json::from_str(body_str).map_err(|e| format!("Invalid JSON: {e}"))?;
+    if let JsonValue::String(s) = &v {
+        return Ok(s.trim().to_string());
+    }
+    if let JsonValue::Object(map) = &v {
+        for key in ["text", "result", "partial", "transcript"] {
+            if let Some(JsonValue::String(s)) = map.get(key) {
+                let t = s.trim();
+                if !t.is_empty() {
+                    return Ok(t.to_string());
+                }
+            }
+        }
+        if let Some(JsonValue::Object(nested)) = map.get("response") {
+            if let Some(JsonValue::String(s)) = nested.get("text") {
+                return Ok(s.trim().to_string());
+            }
+        }
+    }
+    Ok(String::new())
+}
+
+fn query_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(*b as char);
+            }
+            _ => {
+                use std::fmt::Write;
+                let _ = write!(out, "%{b:02X}");
+            }
+        }
+    }
+    out
+}
+
+/// Parse the OminiX transcription response (`{"text": "..."}`).
 pub fn parse_transcribe_response(response: &HttpResponse) -> Result<String, String> {
     if response.status_code != 200 {
         return Err(format!("HTTP {}", response.status_code));
@@ -85,7 +226,11 @@ pub fn parse_transcribe_response(response: &HttpResponse) -> Result<String, Stri
     Err(format!("Unexpected response format: {body_str}"))
 }
 
-/// Simple base64 encoder (no external deps).
+/// Minimal float32 silence for connectivity test (~0.2 s at 16 kHz mono; f32le = 4 bytes/sample).
+pub fn test_stream_silence_pcm() -> &'static [u8] {
+    &[0u8; 3200 * 4]
+}
+
 fn base64_encode(data: &[u8]) -> String {
     const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     let mut result = String::with_capacity((data.len() + 2) / 3 * 4);

--- a/macos-sys/Cargo.toml
+++ b/macos-sys/Cargo.toml
@@ -11,4 +11,4 @@ log = "0.4"
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"
 core-graphics = "0.24"
-makepad-objc-sys = { path = "/Users/zhangalex/Work/Projects/FW/robius/makepad/libs/objc-sys" }
+makepad-objc-sys.workspace = true


### PR DESCRIPTION
## Summary
- Remove hard-coded `path = "/Users/.../makepad/..."` for `makepad-widgets` and `makepad-objc-sys`.
- Add `[workspace.dependencies]` pointing at `makepad/makepad` with a pinned `rev`, and use `*.workspace = true` in member crates.
- Refresh `Cargo.lock`.

## Why
Forks and CI should build without a local Makepad checkout. GitHub-sourced deps also avoid registry mirrors that only publish `makepad-widgets` 1.x.