### PR TITLE
feat: add meeting minutes mode (v0.2)

### DIFF
--- a/app/src/audio.rs
+++ b/app/src/audio.rs
@@ -109,6 +109,27 @@ impl AudioCapture {
         }
     }
 
+    /// Drain accumulated PCM samples without stopping recording.
+    /// Used by meeting mode to chunk audio while continuing capture.
+    pub fn drain_chunk(&self) -> Vec<f32> {
+        let device_sr =
+            f64::from_bits(self.device_sample_rate.load(Ordering::Relaxed));
+        let samples = if let Ok(mut buf) = self.pcm_buffer.lock() {
+            std::mem::take(&mut *buf)
+        } else {
+            return Vec::new();
+        };
+
+        if samples.is_empty() {
+            return Vec::new();
+        }
+
+        if (device_sr - TARGET_SAMPLE_RATE).abs() < 1.0 {
+            return samples;
+        }
+        resample(&samples, device_sr, TARGET_SAMPLE_RATE)
+    }
+
     /// Stop recording and return PCM samples resampled to 16kHz mono.
     pub fn stop(&mut self, cx: &mut Cx) -> Vec<f32> {
         self.active.store(false, Ordering::Relaxed);

--- a/app/src/config.rs
+++ b/app/src/config.rs
@@ -14,6 +14,9 @@ pub struct AppConfig {
 
     #[serde(default)]
     pub llm_refine: LlmRefineConfig,
+
+    #[serde(default)]
+    pub meeting: MeetingConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,6 +60,58 @@ pub struct LlmRefineConfig {
     pub model: String,
     #[serde(default = "default_system_prompt")]
     pub system_prompt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeetingConfig {
+    #[serde(default = "default_chunk_duration")]
+    pub chunk_duration_secs: u32,
+    #[serde(default = "default_meeting_output_dir")]
+    pub output_dir: String,
+    #[serde(default = "default_true")]
+    pub auto_summary: bool,
+    #[serde(default = "default_summary_prompt")]
+    pub summary_system_prompt: String,
+}
+
+impl Default for MeetingConfig {
+    fn default() -> Self {
+        Self {
+            chunk_duration_secs: default_chunk_duration(),
+            output_dir: default_meeting_output_dir(),
+            auto_summary: true,
+            summary_system_prompt: default_summary_prompt(),
+        }
+    }
+}
+
+fn default_chunk_duration() -> u32 { 30 }
+fn default_true() -> bool { true }
+fn default_meeting_output_dir() -> String {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    format!("{}/Documents/Vox", home)
+}
+fn default_summary_prompt() -> String {
+    r#"You are a meeting minutes assistant. Given a full meeting transcript, generate a structured summary.
+
+Output format (Markdown):
+## Summary
+(2-3 sentence overview)
+
+## Key Points
+- (bulleted list of important topics discussed)
+
+## Decisions
+- (bulleted list of decisions made, if any)
+
+## Action Items
+- [ ] (task) — assigned to (person), deadline (if mentioned)
+
+Rules:
+- Be concise and factual
+- Only include information explicitly stated in the transcript
+- If no decisions or action items were discussed, omit those sections
+- Output ONLY the Markdown, no preamble"#.to_string()
 }
 
 fn default_language() -> String { "zh".to_string() }
@@ -117,6 +172,7 @@ impl Default for AppConfig {
             hotkey: HotkeyConfig::default(),
             ominix_api: OminixApiConfig::default(),
             llm_refine: LlmRefineConfig::default(),
+            meeting: MeetingConfig::default(),
         }
     }
 }

--- a/app/src/llm_refine.rs
+++ b/app/src/llm_refine.rs
@@ -1,6 +1,7 @@
 use makepad_widgets::*;
 
 pub const LLM_REFINE_REQUEST_ID: LiveId = live_id!(llm_refine);
+pub const LLM_SUMMARY_REQUEST_ID: LiveId = live_id!(llm_summary);
 
 /// Send an LLM refine request to correct transcription errors.
 pub fn send_refine_request(
@@ -33,6 +34,32 @@ pub fn send_refine_request(
 
     cx.http_request(LLM_REFINE_REQUEST_ID, req);
     log!("LLM refine request sent");
+}
+
+/// Send a meeting summary request to LLM.
+pub fn send_summary_request(
+    cx: &mut Cx,
+    api_base_url: &str,
+    api_key: &str,
+    model: &str,
+    system_prompt: &str,
+    transcript: &str,
+) {
+    let url = format!("{}/v1/chat/completions", api_base_url.trim_end_matches('/'));
+    let body = format!(
+        r#"{{"model":"{}","messages":[{{"role":"system","content":{}}},{{"role":"user","content":{}}}],"temperature":0.2,"max_tokens":4096}}"#,
+        model,
+        serde_json::to_string(system_prompt).unwrap_or_default(),
+        serde_json::to_string(transcript).unwrap_or_default(),
+    );
+    let mut req = HttpRequest::new(url, HttpMethod::POST);
+    req.set_header("Content-Type".into(), "application/json".into());
+    if !api_key.is_empty() {
+        req.set_header("Authorization".into(), format!("Bearer {api_key}"));
+    }
+    req.set_body(body.into_bytes());
+    cx.http_request(LLM_SUMMARY_REQUEST_ID, req);
+    log!("LLM summary request sent");
 }
 
 /// Parse the LLM refine response.

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -8,6 +8,7 @@ use makepad_widgets::*;
 mod audio;
 mod config;
 mod llm_refine;
+mod meeting;
 mod text_inject;
 mod transcribe;
 
@@ -23,12 +24,20 @@ const MENU_LANG_KO: u64 = 14;
 const MENU_LANG_WEN: u64 = 15;
 const MENU_LLM_TOGGLE: u64 = 20;
 const MENU_SETTINGS: u64 = 21;
+const MENU_MEETING_START: u64 = 30;
+const MENU_MEETING_STOP: u64 = 31;
 const MENU_TEST_CAPSULE: u64 = 99;
 
+// Normal mode states
 const STATE_IDLE: u8 = 0;
 const STATE_RECORDING: u8 = 1;
 const STATE_TRANSCRIBING: u8 = 2;
 const STATE_REFINING: u8 = 3;
+
+// Meeting mode states (10+ range)
+const STATE_MEETING_RECORDING: u8 = 10;
+const STATE_MEETING_FINALIZING: u8 = 11;
+const STATE_MEETING_SUMMARIZING: u8 = 12;
 
 /// Qwen/vLLM streaming ASR in-flight step (after `POST /api/start`).
 #[allow(clippy::enum_variant_names)]
@@ -222,6 +231,11 @@ struct Inner {
     asr_stream_phase: Option<AsrStreamPhase>,
     test_asr_stream_phase: TestAsrStreamPhase,
     test_asr_stream_session_id: String,
+    // Meeting mode
+    meeting_session: Option<meeting::MeetingSession>,
+    chunk_timer: Timer,
+    meeting_display_timer: Timer,
+    chunk_queue: std::collections::VecDeque<Vec<u8>>,
 }
 
 #[derive(Script, ScriptHook)]
@@ -289,6 +303,14 @@ impl App {
                 MenuItem::new("Settings...", MENU_SETTINGS),
             ]),
             MenuItem::separator(),
+            MenuItem::submenu("Meeting Mode", vec![
+                if self.inner.state >= STATE_MEETING_RECORDING {
+                    MenuItem::new("Stop Meeting", MENU_MEETING_STOP)
+                } else {
+                    MenuItem::new("Start Meeting", MENU_MEETING_START)
+                },
+            ]),
+            MenuItem::separator(),
             MenuItem::new("Test Capsule", MENU_TEST_CAPSULE),
             MenuItem::separator(),
             MenuItem::new("Quit", MENU_QUIT),
@@ -329,6 +351,12 @@ impl App {
             }
             MENU_SETTINGS => {
                 self.show_settings(cx);
+            }
+            MENU_MEETING_START => {
+                self.start_meeting(cx);
+            }
+            MENU_MEETING_STOP => {
+                self.stop_meeting(cx);
             }
             MENU_TEST_CAPSULE => {
                 self.show_capsule(cx);
@@ -607,9 +635,231 @@ impl App {
         let raw_rms = self.inner.audio.read_rms();
         let alpha = if raw_rms > self.inner.smooth_rms { 0.4 } else { 0.15 };
         self.inner.smooth_rms += (raw_rms - self.inner.smooth_rms) * alpha;
-
-        // Redraw the entire capsule window to update draw_pass.time in shader
         self.ui.widget(cx, ids!(capsule_window)).redraw(cx);
+    }
+
+    // === Meeting Mode ===
+
+    fn start_meeting(&mut self, cx: &mut Cx) {
+        if self.inner.state != STATE_IDLE { return; }
+
+        let output_dir = std::path::PathBuf::from(&self.inner.config.meeting.output_dir);
+        let _ = std::fs::create_dir_all(&output_dir);
+
+        self.inner.meeting_session = Some(meeting::MeetingSession::new(
+            &output_dir,
+            &self.inner.config.language,
+        ));
+        self.inner.state = STATE_MEETING_RECORDING;
+        self.inner.chunk_queue.clear();
+
+        // Start audio
+        self.inner.audio.start(cx);
+
+        // Start chunk timer
+        let chunk_secs = self.inner.config.meeting.chunk_duration_secs as f64;
+        self.inner.chunk_timer = cx.start_interval(chunk_secs);
+
+        // Start display update timer (1s)
+        self.inner.meeting_display_timer = cx.start_interval(1.0);
+
+        // Start animation frame
+        self.inner.waveform_next_frame = cx.new_next_frame();
+
+        // Show capsule
+        self.show_capsule(cx);
+        self.update_meeting_display(cx);
+        self.refresh_menu();
+
+        // Status bar icon
+        if let Some(ref handle) = self.inner.status_bar_handle {
+            macos_sys::status_bar::set_status_bar_icon(handle, "📝");
+        }
+
+        log!("Meeting started");
+    }
+
+    fn stop_meeting(&mut self, cx: &mut Cx) {
+        if self.inner.state != STATE_MEETING_RECORDING { return; }
+
+        // Stop chunk timer
+        cx.stop_timer(self.inner.chunk_timer);
+        cx.stop_timer(self.inner.meeting_display_timer);
+
+        // Drain remaining audio as final chunk
+        let remaining = self.inner.audio.drain_chunk();
+        self.inner.audio.stop(cx);
+
+        if !remaining.is_empty() {
+            let wav = audio::encode_wav(&remaining, 16_000);
+            if let Some(ref mut session) = self.inner.meeting_session {
+                session.pending_chunks += 1;
+                session.next_chunk_index += 1;
+            }
+            // Queue or send
+            if self.inner.meeting_session.as_ref().map_or(false, |s| s.pending_chunks == 1) {
+                transcribe::send_meeting_chunk_request(
+                    cx,
+                    &self.inner.config.ominix_api.base_url,
+                    &wav,
+                    &self.inner.config.language,
+                    &self.inner.config.ominix_api.asr_model,
+                );
+            } else {
+                self.inner.chunk_queue.push_back(wav);
+            }
+        }
+
+        self.inner.state = STATE_MEETING_FINALIZING;
+        self.ui.label(cx, ids!(transcript_label))
+            .set_text(cx, "📝 Finishing up...");
+
+        log!("Meeting stopping, waiting for pending chunks");
+
+        // If no pending chunks, finalize immediately
+        self.try_finalize_meeting(cx);
+    }
+
+    fn handle_chunk_tick(&mut self, cx: &mut Cx) {
+        if self.inner.state != STATE_MEETING_RECORDING { return; }
+
+        let samples = self.inner.audio.drain_chunk();
+        if samples.is_empty() { return; }
+
+        let wav = audio::encode_wav(&samples, 16_000);
+
+        if let Some(ref mut session) = self.inner.meeting_session {
+            session.next_chunk_index += 1;
+            session.pending_chunks += 1;
+        }
+
+        // Send or queue
+        let pending = self.inner.meeting_session.as_ref().map_or(0, |s| s.pending_chunks);
+        if pending == 1 {
+            transcribe::send_meeting_chunk_request(
+                cx,
+                &self.inner.config.ominix_api.base_url,
+                &wav,
+                &self.inner.config.language,
+                &self.inner.config.ominix_api.asr_model,
+            );
+        } else {
+            self.inner.chunk_queue.push_back(wav);
+        }
+    }
+
+    fn handle_meeting_chunk_response(&mut self, cx: &mut Cx, text: &str) {
+        if let Some(ref mut session) = self.inner.meeting_session {
+            session.pending_chunks = session.pending_chunks.saturating_sub(1);
+            session.add_chunk_result(text);
+        }
+
+        // Send next queued chunk
+        if let Some(wav) = self.inner.chunk_queue.pop_front() {
+            if let Some(ref mut session) = self.inner.meeting_session {
+                session.pending_chunks += 1;
+            }
+            transcribe::send_meeting_chunk_request(
+                cx,
+                &self.inner.config.ominix_api.base_url,
+                &wav,
+                &self.inner.config.language,
+                &self.inner.config.ominix_api.asr_model,
+            );
+        }
+
+        self.update_meeting_display(cx);
+
+        // If finalizing and no more pending, proceed
+        if self.inner.state == STATE_MEETING_FINALIZING {
+            self.try_finalize_meeting(cx);
+        }
+    }
+
+    fn try_finalize_meeting(&mut self, cx: &mut Cx) {
+        let pending = self.inner.meeting_session.as_ref().map_or(0, |s| s.pending_chunks);
+        if pending > 0 { return; }
+
+        // Finalize transcript.md
+        if let Some(ref mut session) = self.inner.meeting_session {
+            session.finalize_transcript();
+        }
+
+        // LLM summary if configured
+        let cfg = &self.inner.config;
+        let has_llm = cfg.meeting.auto_summary
+            && !cfg.llm_refine.api_base_url.is_empty()
+            && !cfg.llm_refine.api_key.is_empty();
+
+        if has_llm {
+            let transcript = self.inner.meeting_session.as_ref()
+                .map(|s| s.full_transcript())
+                .unwrap_or_default();
+            if !transcript.is_empty() {
+                self.inner.state = STATE_MEETING_SUMMARIZING;
+                self.ui.label(cx, ids!(transcript_label))
+                    .set_text(cx, "📝 Generating summary...");
+                llm_refine::send_summary_request(
+                    cx,
+                    &cfg.llm_refine.api_base_url,
+                    &cfg.llm_refine.api_key,
+                    &cfg.llm_refine.model,
+                    &cfg.meeting.summary_system_prompt,
+                    &transcript,
+                );
+                return;
+            }
+        }
+
+        // No LLM, save directly
+        self.save_meeting(cx, None);
+    }
+
+    fn save_meeting(&mut self, cx: &mut Cx, summary: Option<&str>) {
+        if let Some(ref session) = self.inner.meeting_session {
+            if let Some(summary_text) = summary {
+                if let Err(e) = session.save_summary(summary_text) {
+                    log!("Failed to save summary: {}", e);
+                }
+            }
+            let path = session.output_path().display().to_string();
+            self.ui.label(cx, ids!(transcript_label))
+                .set_text(cx, &format!("📝 Saved: {}", path));
+        }
+
+        // Clean up
+        self.inner.meeting_session = None;
+        self.inner.state = STATE_IDLE;
+        self.inner.chunk_queue.clear();
+        self.inner.error_dismiss_timer = cx.start_timeout(5.0);
+        self.refresh_menu();
+
+        // Restore status bar icon
+        if let Some(ref handle) = self.inner.status_bar_handle {
+            macos_sys::status_bar::set_status_bar_icon(handle, "MIC");
+        }
+
+        log!("Meeting saved");
+    }
+
+    fn update_meeting_display(&mut self, cx: &mut Cx) {
+        if let Some(ref session) = self.inner.meeting_session {
+            let elapsed = session.elapsed_display();
+            let chunks = session.chunks.len();
+            let latest = session.latest_text();
+            let display = if latest.is_empty() {
+                format!("📝 Meeting {} | {} chunks", elapsed, chunks)
+            } else {
+                // Show last ~30 chars of latest text
+                let truncated = if latest.len() > 30 {
+                    format!("...{}", &latest[latest.len()-30..])
+                } else {
+                    latest.to_string()
+                };
+                format!("📝 {} | {} {}", elapsed, chunks, truncated)
+            };
+            self.ui.label(cx, ids!(transcript_label)).set_text(cx, &display);
+        }
     }
 }
 
@@ -648,6 +898,13 @@ impl MatchEvent for App {
         if self.inner.deferred_setup_timer.is_timer(event).is_some() {
                 self.setup_status_bar();
         }
+        // Meeting mode timers
+        if self.inner.chunk_timer.is_timer(event).is_some() {
+            self.handle_chunk_tick(cx);
+        }
+        if self.inner.meeting_display_timer.is_timer(event).is_some() {
+            self.update_meeting_display(cx);
+        }
         if self.inner.menu_poll_timer.is_timer(event).is_some() {
             let menu_actions: Vec<u64> = self.inner.menu_rx.as_ref()
                 .map(|rx| rx.try_iter().collect()).unwrap_or_default();
@@ -662,10 +919,13 @@ impl MatchEvent for App {
                     let _ = writeln!(f, "APP: received {} hotkey events", hotkey_events.len());
                 }
             }
-            for evt in hotkey_events {
-                match evt {
-                    macos_sys::event_tap::HotkeyEvent::Pressed => self.start_recording(cx),
-                    macos_sys::event_tap::HotkeyEvent::Released => self.stop_recording(cx),
+            // Block hotkey during meeting mode
+            if self.inner.state < STATE_MEETING_RECORDING {
+                for evt in hotkey_events {
+                    match evt {
+                        macos_sys::event_tap::HotkeyEvent::Pressed => self.start_recording(cx),
+                        macos_sys::event_tap::HotkeyEvent::Released => self.stop_recording(cx),
+                    }
                 }
             }
         }
@@ -786,6 +1046,19 @@ impl MatchEvent for App {
                     self.inner.state = STATE_IDLE;
                 }
             }
+        } else if request_id == transcribe::MEETING_CHUNK_REQUEST_ID {
+            match transcribe::parse_transcribe_response(response) {
+                Ok(text) => self.handle_meeting_chunk_response(cx, &text),
+                Err(e) => self.handle_meeting_chunk_response(cx, &format!("(error: {e})")),
+            }
+        } else if request_id == llm_refine::LLM_SUMMARY_REQUEST_ID {
+            match llm_refine::parse_refine_response(response) {
+                Ok(summary) => self.save_meeting(cx, Some(&summary)),
+                Err(e) => {
+                    log!("LLM summary failed: {}", e);
+                    self.save_meeting(cx, None);
+                }
+            }
         } else if request_id == live_id!(test_connection) {
             if response.status_code == 200 {
                 self.ui.label(cx, ids!(settings_status)).set_text(cx, "Connected");
@@ -817,6 +1090,11 @@ impl MatchEvent for App {
             let original = self.inner.last_transcription.clone();
             self.inject_text(cx, &original);
             self.inner.state = STATE_IDLE;
+        } else if request_id == transcribe::MEETING_CHUNK_REQUEST_ID {
+            self.handle_meeting_chunk_response(cx, "(transcription failed)");
+        } else if request_id == llm_refine::LLM_SUMMARY_REQUEST_ID {
+            log!("LLM summary request failed");
+            self.save_meeting(cx, None);
         } else if request_id == live_id!(test_connection) {
             self.ui.label(cx, ids!(settings_status)).set_text(cx, "Connection failed");
         }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -686,9 +686,10 @@ impl App {
         cx.stop_timer(self.inner.chunk_timer);
         cx.stop_timer(self.inner.meeting_display_timer);
 
-        // Drain remaining audio as final chunk
-        let remaining = self.inner.audio.drain_chunk();
-        self.inner.audio.stop(cx);
+        // Drain buffered audio + any frames captured during stop
+        let mut remaining = self.inner.audio.drain_chunk();
+        let tail = self.inner.audio.stop(cx);
+        remaining.extend_from_slice(&tail);
 
         if !remaining.is_empty() {
             let wav = audio::encode_wav(&remaining, 16_000);
@@ -754,11 +755,8 @@ impl App {
             session.add_chunk_result(text);
         }
 
-        // Send next queued chunk
+        // Send next queued chunk (already counted in pending_chunks when queued)
         if let Some(wav) = self.inner.chunk_queue.pop_front() {
-            if let Some(ref mut session) = self.inner.meeting_session {
-                session.pending_chunks += 1;
-            }
             transcribe::send_meeting_chunk_request(
                 cx,
                 &self.inner.config.ominix_api.base_url,
@@ -850,9 +848,10 @@ impl App {
             let display = if latest.is_empty() {
                 format!("📝 Meeting {} | {} chunks", elapsed, chunks)
             } else {
-                // Show last ~30 chars of latest text
-                let truncated = if latest.len() > 30 {
-                    format!("...{}", &latest[latest.len()-30..])
+                // Show last ~15 chars of latest text (char-safe for CJK)
+                let chars: Vec<char> = latest.chars().collect();
+                let truncated = if chars.len() > 15 {
+                    format!("...{}", chars[chars.len()-15..].iter().collect::<String>())
                 } else {
                     latest.to_string()
                 };

--- a/app/src/meeting.rs
+++ b/app/src/meeting.rs
@@ -1,0 +1,213 @@
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+/// A single chunk of transcribed audio.
+pub struct ChunkResult {
+    pub index: u32,
+    pub text: String,
+    pub timestamp_offset_secs: f64,
+}
+
+/// State for an active meeting session.
+pub struct MeetingSession {
+    pub start_time: Instant,
+    pub start_datetime: String,
+    pub chunks: Vec<ChunkResult>,
+    pub pending_chunks: u32,
+    pub next_chunk_index: u32,
+    pub output_dir: PathBuf,
+    file_handle: Option<std::fs::File>,
+}
+
+impl MeetingSession {
+    pub fn new(output_dir: &Path, language: &str) -> Self {
+        let now = chrono_now();
+        let start_datetime = now.clone();
+        let session_dir = output_dir.join(format!("meeting_{}", now));
+        let _ = std::fs::create_dir_all(&session_dir);
+
+        // Create transcript.md with header immediately
+        let transcript_path = session_dir.join("transcript.md");
+        let header = format!(
+            "# Meeting Transcript — {}\n\n**Language:** {}\n\n---\n\n",
+            format_display_time(&now),
+            language,
+        );
+        let file_handle = std::fs::File::create(&transcript_path)
+            .ok()
+            .map(|mut f| {
+                use std::io::Write;
+                let _ = f.write_all(header.as_bytes());
+                f
+            });
+
+        Self {
+            start_time: Instant::now(),
+            start_datetime,
+            chunks: Vec::new(),
+            pending_chunks: 0,
+            next_chunk_index: 0,
+            output_dir: session_dir,
+            file_handle,
+        }
+    }
+
+    pub fn elapsed_secs(&self) -> f64 {
+        self.start_time.elapsed().as_secs_f64()
+    }
+
+    pub fn elapsed_display(&self) -> String {
+        let secs = self.elapsed_secs() as u64;
+        let m = secs / 60;
+        let s = secs % 60;
+        format!("{:02}:{:02}", m, s)
+    }
+
+    /// Add a chunk result and immediately append to transcript.md.
+    pub fn add_chunk_result(&mut self, text: &str) {
+        let offset = self.chunks.len() as f64 * 30.0; // approximate
+        let index = self.chunks.len() as u32;
+
+        let chunk = ChunkResult {
+            index,
+            text: text.to_string(),
+            timestamp_offset_secs: offset,
+        };
+
+        // Append to file immediately
+        if let Some(ref mut f) = self.file_handle {
+            use std::io::Write;
+            let ts = format_timestamp(offset);
+            let _ = writeln!(f, "[{}] {}\n", ts, text);
+            let _ = f.flush();
+        }
+
+        self.chunks.push(chunk);
+    }
+
+    /// Get the full transcript text (for LLM summary).
+    pub fn full_transcript(&self) -> String {
+        self.chunks
+            .iter()
+            .map(|c| {
+                let ts = format_timestamp(c.timestamp_offset_secs);
+                format!("[{}] {}", ts, c.text)
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Get the latest chunk text (for capsule display).
+    pub fn latest_text(&self) -> &str {
+        self.chunks
+            .last()
+            .map(|c| c.text.as_str())
+            .unwrap_or("")
+    }
+
+    /// Finalize transcript.md with duration and chunk count.
+    pub fn finalize_transcript(&mut self) {
+        let elapsed = self.elapsed_display();
+        let chunk_count = self.chunks.len();
+        if let Some(ref mut f) = self.file_handle {
+            use std::io::Write;
+            let _ = writeln!(
+                f,
+                "\n---\n\n**Duration:** {}\n**Chunks:** {}\n",
+                elapsed,
+                chunk_count
+            );
+            let _ = f.flush();
+        }
+    }
+
+    /// Save summary.md with LLM-generated content.
+    pub fn save_summary(&self, summary: &str) -> Result<(), String> {
+        let path = self.output_dir.join("summary.md");
+        let content = format!(
+            "# Meeting Summary — {}\n\n**Duration:** {}\n**Chunks:** {}\n\n---\n\n{}\n",
+            format_display_time(&self.start_datetime),
+            self.elapsed_display(),
+            self.chunks.len(),
+            summary,
+        );
+        std::fs::write(&path, content).map_err(|e| e.to_string())
+    }
+
+    /// Get the session output directory path.
+    pub fn output_path(&self) -> &Path {
+        &self.output_dir
+    }
+}
+
+fn format_timestamp(secs: f64) -> String {
+    let total = secs as u64;
+    let m = total / 60;
+    let s = total % 60;
+    format!("{:02}:{:02}", m, s)
+}
+
+fn format_display_time(datetime_str: &str) -> String {
+    // Convert "2026-04-01_143022" to "2026-04-01 14:30"
+    if datetime_str.len() >= 15 {
+        let date = &datetime_str[..10];
+        let h = &datetime_str[11..13];
+        let m = &datetime_str[13..15];
+        format!("{} {}:{}", date, h, m)
+    } else {
+        datetime_str.to_string()
+    }
+}
+
+fn chrono_now() -> String {
+    // Simple timestamp without chrono dependency
+    use std::time::SystemTime;
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Convert unix timestamp to YYYY-MM-DD_HHMMSS
+    // Simple calculation (not timezone-aware, but good enough)
+    let secs_per_day = 86400u64;
+    let days = now / secs_per_day;
+    let day_secs = now % secs_per_day;
+    let h = day_secs / 3600;
+    let m = (day_secs % 3600) / 60;
+    let s = day_secs % 60;
+
+    // Days since epoch to Y-M-D (simplified, no leap second handling)
+    let (year, month, day) = days_to_ymd(days);
+    format!("{:04}-{:02}-{:02}_{:02}{:02}{:02}", year, month, day, h, m, s)
+}
+
+fn days_to_ymd(days: u64) -> (u64, u64, u64) {
+    // Simplified date calculation from days since epoch (1970-01-01)
+    let mut y = 1970u64;
+    let mut remaining = days;
+    loop {
+        let days_in_year = if is_leap(y) { 366 } else { 365 };
+        if remaining < days_in_year {
+            break;
+        }
+        remaining -= days_in_year;
+        y += 1;
+    }
+    let months_days: [u64; 12] = if is_leap(y) {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+    let mut m = 1u64;
+    for &md in &months_days {
+        if remaining < md {
+            break;
+        }
+        remaining -= md;
+        m += 1;
+    }
+    (y, m, remaining + 1)
+}
+
+fn is_leap(y: u64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}

--- a/app/src/transcribe.rs
+++ b/app/src/transcribe.rs
@@ -3,6 +3,7 @@ use serde_json::Value as JsonValue;
 
 /// Request ID for OminiX-style single-shot transcription.
 pub const TRANSCRIBE_REQUEST_ID: LiveId = live_id!(transcribe);
+pub const MEETING_CHUNK_REQUEST_ID: LiveId = live_id!(meeting_chunk);
 
 /// Streaming ASR: matches Python `QwenStreamingASRClient` (start → chunk → finish).
 pub const ASR_STREAM_START_ID: LiveId = live_id!(asr_stream_start);
@@ -48,6 +49,26 @@ pub fn send_transcribe_request(
     req.set_body(body.into_bytes());
 
     cx.http_request(TRANSCRIBE_REQUEST_ID, req);
+}
+
+/// Send a meeting chunk transcription request (same format as OminiX, different request ID).
+pub fn send_meeting_chunk_request(cx: &mut Cx, base_url: &str, wav_data: &[u8], language: &str, model: &str) {
+    let url = format!("{}/v1/audio/transcriptions", base_url.trim_end_matches('/'));
+    let asr_language = match language {
+        "zh" => "Chinese", "en" => "English", "ja" => "Japanese",
+        "ko" => "Korean", "zh-TW" => "Chinese", "wen" => "Chinese",
+        _ => language,
+    };
+    let b64 = base64_encode(wav_data);
+    let body = serde_json::json!({
+        "file": b64,
+        "language": asr_language,
+        "model": model,
+    }).to_string();
+    let mut req = HttpRequest::new(url, HttpMethod::POST);
+    req.set_header("Content-Type".into(), "application/json".into());
+    req.set_body(body.into_bytes());
+    cx.http_request(MEETING_CHUNK_REQUEST_ID, req);
 }
 
 /// Map app language to ISO code for `/api/start` (matches typical `ASR_LANGUAGE` env usage).
@@ -178,6 +199,8 @@ fn query_escape(s: &str) -> String {
 }
 
 /// Parse the OminiX transcription response (`{"text": "..."}`).
+/// Parse the OminiX transcription response (`{"text": "..."}`).
+
 pub fn parse_transcribe_response(response: &HttpResponse) -> Result<String, String> {
     if response.status_code != 200 {
         return Err(format!("HTTP {}", response.status_code));


### PR DESCRIPTION
New "Meeting Mode" for continuous recording with auto-chunking:
- Menu: Start Meeting / Stop Meeting
- Auto-chunks every 30s, sends each to ASR independently
- Sequential HTTP requests (one in-flight, rest queued)
- Real-time transcript append to transcript.md (crash-safe)
- LLM summary after meeting end → summary.md
- Capsule shows elapsed time + chunk count
- Option hotkey disabled during meeting (prevents accidental stop)
- Output: ~/Documents/Vox/meeting_YYYY-MM-DD_HHMMSS/

New files:
- app/src/meeting.rs — MeetingSession, ChunkResult, Markdown generation

Modified:
- audio.rs: drain_chunk() for non-stop buffer drain
- config.rs: MeetingConfig (chunk_duration, output_dir, auto_summary)
- transcribe.rs: MEETING_CHUNK_REQUEST_ID
- llm_refine.rs: LLM_SUMMARY_REQUEST_ID, send_summary_request()
- main.rs: meeting states (10-12), menu, timers, chunk flow